### PR TITLE
feat: get theme preference from user if not set

### DIFF
--- a/src/components/theme-selector.vue
+++ b/src/components/theme-selector.vue
@@ -26,7 +26,19 @@ export default class ThemeSelector
 	public isDarkTheme: boolean = false;
 
 	mounted() {
-		this.isDarkTheme = this.persistThemeService.currentOptions.isDarkTheme ?? false;
+		const maybeIsDarkTheme =
+			this.persistThemeService.currentOptions.isDarkTheme !== undefined;
+
+		if (maybeIsDarkTheme) {
+			this.isDarkTheme =
+				<boolean>this.persistThemeService.currentOptions.isDarkTheme;
+		}
+		else {
+			this.isDarkTheme =
+				window.matchMedia
+				&& window.matchMedia('(prefers-color-scheme: dark)').matches;
+		}
+
 		this.applyTheme();
 	}
 


### PR DESCRIPTION
This implementation checks for media query `prefers-color-scheme` and defaults to light theme in case it's `false` or not supported. 